### PR TITLE
Adding the argument --request-download-timeout

### DIFF
--- a/cs_dlp/commandline.py
+++ b/cs_dlp/commandline.py
@@ -321,6 +321,14 @@ def parse_args(args=None):
         default=False,
         help='Do not limit filenames to be ASCII-only')
 
+    parser.add_argument(
+        '--request-download-timeout',
+        dest='request_download_timeout',
+        action='store',
+        default=None,
+        type=int,
+        help='Number of seconds to wait before ignoring the url. (Default: infinite)')
+
     # Advanced authentication
     group_adv_auth = parser.add_argument_group(
         'Advanced authentication options')

--- a/cs_dlp/downloaders.py
+++ b/cs_dlp/downloaders.py
@@ -321,8 +321,9 @@ class NativeDownloader(Downloader):
     :param session: Requests session.
     """
 
-    def __init__(self, session):
+    def __init__(self, session, args):
         self.session = session
+        self.args = args
 
     def _start_download(self, url, filename, resume=False):
         # resume has no meaning if the file doesn't exists!
@@ -341,7 +342,7 @@ class NativeDownloader(Downloader):
         attempts_count = 0
         error_msg = ''
         while attempts_count < max_attempts:
-            r = self.session.get(url, stream=True, headers=headers)
+            r = self.session.get(url, stream=True, headers=headers, timeout=self.args.request_download_timeout)
 
             if r.status_code != 200:
                 # because in resume state we are downloading only a
@@ -418,4 +419,4 @@ def get_downloader(session, class_name, args):
             return class_(session, bin=getattr(args, bin),
                           downloader_arguments=args.downloader_arguments)
 
-    return NativeDownloader(session)
+    return NativeDownloader(session, args)


### PR DESCRIPTION
Adding the argument --request-download-timeout to set a timeout in seconds when downloading urls.

Sometime external resources can hang the process indefinitely. Adding a timeout allow the process to continue with the others elements.