### PR TITLE
Add `webmVideoUrl` as a backup

### DIFF
--- a/cs_dlp/libs/api.py
+++ b/cs_dlp/libs/api.py
@@ -517,7 +517,7 @@ class VideosV1(object):
     @staticmethod
     def from_json(data):
 
-        videos = [VideoV1(resolution, links['mp4VideoUrl'])
+        videos = [VideoV1(resolution, links.get('mp4VideoUrl', links.get('webmVideoUrl')))
                   for resolution, links
                   in data['sources']['byResolution'].items()]
         videos.sort(key=lambda video: video.resolution, reverse=True)


### PR DESCRIPTION
Some videos don't have mp4  links so `links['mp4VideoUrl']` fails with NoSuchKey exception. This change allows to try webmVideoUrl as a backup.